### PR TITLE
Returning an actual status in getStatus

### DIFF
--- a/src/main/java/com/couchbase/cblite/listener/CBLListener.java
+++ b/src/main/java/com/couchbase/cblite/listener/CBLListener.java
@@ -19,6 +19,7 @@ public class CBLListener implements Runnable {
     private CBLHTTPServer httpServer;
     public static final String TAG = "CBLListener";
     private int listenPort;
+    private int serverStatus;
 
     //static inializer to ensure that cblite:// URLs are handled properly
     {
@@ -69,7 +70,7 @@ public class CBLListener implements Runnable {
 
     @Override
     public void run() {
-        httpServer.serve();
+        this.serverStatus = httpServer.serve();
     }
 
     public void start() {
@@ -87,8 +88,7 @@ public class CBLListener implements Runnable {
     }
 
     public String getStatus() {
-        String status = this.httpServer.getServerInfo();
-        return status;
+        return "" + this.serverStatus;
     }
 
     public int getListenPort() {


### PR DESCRIPTION
Hey guys, 

here is a patch I was using back in my project that depended on touchdb https://github.com/cesine/TouchDB-Android/commit/227a558204f8ac84f0bfb48cc4ec3b1ab03d0162

we are still building with eclipse so I probably wont add the test unless I have extra free time. here is the gist: basically calling getStatus() now should return 0 if the server is on. I figure it might be useful for others too...

---

Before getStatus was returning static variables about the ACME server, not really a status message about if the server turned on successfully. This is simply returning the result of httpServer.serve() instead of httpServer.getServerInfo()
## 
## Before
- http://acme.com/java/software/Acme.Serve.Serve.html

Return:
- always returned something like this: D. Rogatkin's TJWS with Android support (Acme.Serve) Version 1.94, $Revision: 1.236 $ (http://tjws.sourceforge.net)

```
getServerInfo
public String getServerInfo() 
Returns the name and version of the web server under which the servlet is running. Same as the CGI variable SERVER_SOFTWARE.
```
## 
## After
- http://tjws.cvs.sourceforge.net/viewvc/tjws/tjws/src/Acme/Serve/Serve.java?view=markup

Return:
- 0 if successful
- 1 and -1 are error conditions (i guess i could wrap them in a less transparent fashion...)

``` java

814         public int serve() {
...
821                 } catch (IOException e) {
822                         log("Server socket: " + e);
823                         return 1;
824                 }
...
921                 } catch (Throwable t) {
922                         log("Unhandled exception: " + t + ", server is terminating.", t);
923                         return -1;
924                 } 
....
930                 return 0;
```
