### PR TITLE
allow LiteListener to be instantiated with custom properties for the TJWS

### DIFF
--- a/src/main/java/com/couchbase/lite/listener/LiteListener.java
+++ b/src/main/java/com/couchbase/lite/listener/LiteListener.java
@@ -2,6 +2,7 @@ package com.couchbase.lite.listener;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.Properties;
 import java.util.concurrent.ScheduledExecutorService;
 
 
@@ -32,7 +33,8 @@ public class LiteListener implements Runnable {
      * @param allowedCredentials any clients connecting to this liteserv must present these
      *                           credentials.
      */
-    public LiteListener(Manager manager, int suggestedPort, Credentials allowedCredentials) {
+
+    public LiteListener(Manager manager, int suggestedPort, Credentials allowedCredentials, Properties tjwsProperties) {
         this.manager = manager;
         this.httpServer = new LiteServer();
         this.httpServer.setManager(manager);
@@ -40,6 +42,11 @@ public class LiteListener implements Runnable {
         this.listenPort = discoverEmptyPort(suggestedPort);
         this.httpServer.setPort(this.listenPort);
         this.httpServer.setAllowedCredentials(allowedCredentials);
+        this.httpServer.setProps(tjwsProperties);
+    }
+
+    public LiteListener(Manager manager, int suggestedPort, Credentials allowedCredentials) {
+        this(manager, suggestedPort, allowedCredentials, new Properties());
     }
 
     /**

--- a/src/main/java/com/couchbase/lite/listener/LiteServer.java
+++ b/src/main/java/com/couchbase/lite/listener/LiteServer.java
@@ -34,6 +34,10 @@ public class LiteServer extends Serve {
         this.listener = listener;
     }
 
+    public void setProps(Properties properties) {
+        this.props = properties;
+    }
+
     public void setAllowedCredentials(Credentials allowedCredentials) {
         this.allowedCredentials = allowedCredentials;
     }


### PR DESCRIPTION
I've been trying to add SSL to the listener so that my basic auth credentials are not exposed.

Following #28, I've been able to do so but only by adding a new instantiator to the LiteListener class that accepts a Properties object which it passes the LiteServer (who then sets it as arguments on the LiteServlet)

(the existing instantiator works exactly as it did before; passing an empty Properties obj to the LiteServlet arguments)

With this patch, I'm able to enable SSL as explained by @yaronyg in #28:
```java
allowedCredentials = new Credentials(P2P_USERNAME, P2P_PASSWORD);

ThaliCryptoUtilities.getThaliKeyStoreByAnyMeansNecessary(getCtx().getFilesDir());

Properties tjwsProperties = new Properties();
tjwsProperties.setProperty(Serve.ARG_ACCEPTOR_CLASS, "Acme.Serve.SSLAcceptor");
tjwsProperties.setProperty(SSLAcceptor.ARG_KEYSTORETYPE, ThaliCryptoUtilities.PrivateKeyHolderFormat);
tjwsProperties.setProperty(SSLAcceptor.ARG_KEYSTOREFILE, ThaliCryptoUtilities.getThaliKeyStoreFileObject(getCtx().getFilesDir()).getAbsolutePath());
tjwsProperties.setProperty(SSLAcceptor.ARG_KEYSTOREPASS, new String(ThaliCryptoUtilities.DefaultPassPhrase));
tjwsProperties.setProperty(SSLAcceptor.ARG_PORT, String.valueOf(suggestedListenPort));
tjwsProperties.setProperty(Serve.ARG_KEEPALIVE_TIMEOUT, "1"); // Needed to work around https://github.com/couchbase/couchbase-lite-java-listener/issues/40

mListener = new LiteListener(getManager(), suggestedListenPort, allowedCredentials, tjwsProperties);
```

Two notes: 
* I got a copy of ThaliCryptoUtilities here: https://github.com/yaronyg/thali/blob/master/Production/Utilities/UniversalUtilities/src/main/java/com/msopentech/thali/utilities/universal/ThaliCryptoUtilities.java
* The port returned by `mListener.getListenPort()` may not be the port the SSLAcceptor uses. I'm going to try working around this by first calling `mListener.discoverEmptyPort()` to... well, discover an empty port.