### PR TITLE
set properties first so that it doesn't overwrite the port number

### DIFF
--- a/src/main/java/com/couchbase/lite/listener/LiteListener.java
+++ b/src/main/java/com/couchbase/lite/listener/LiteListener.java
@@ -37,12 +37,12 @@ public class LiteListener implements Runnable {
     public LiteListener(Manager manager, int suggestedPort, Credentials allowedCredentials, Properties tjwsProperties) {
         this.manager = manager;
         this.httpServer = new LiteServer();
+        this.httpServer.setProps(tjwsProperties);
         this.httpServer.setManager(manager);
         this.httpServer.setListener(this);
         this.listenPort = discoverEmptyPort(suggestedPort);
         this.httpServer.setPort(this.listenPort);
         this.httpServer.setAllowedCredentials(allowedCredentials);
-        this.httpServer.setProps(tjwsProperties);
     }
 
     public LiteListener(Manager manager, int suggestedPort, Credentials allowedCredentials) {


### PR DESCRIPTION
I made a mistake in my last commit and set the properties after the port was set. this caused the server to start on 8080 instead of the desired port number