### PR TITLE
Log 'missing auth' to Debug instead of Warn.

### DIFF
--- a/src/main/java/com/couchbase/lite/listener/LiteServlet.java
+++ b/src/main/java/com/couchbase/lite/listener/LiteServlet.java
@@ -56,7 +56,7 @@ public class LiteServlet extends HttpServlet {
 
         if (allowedCredentials != null && !allowedCredentials.empty()) {
             if (requestCredentials == null || !requestCredentials.equals(allowedCredentials)) {
-                Log.w(Log.TAG_LISTENER, "Unauthorized -- requestCredentials not given or do not match allowed credentials");
+                Log.d(Log.TAG_LISTENER, "Unauthorized -- requestCredentials not given or do not match allowed credentials");
                 response.setHeader("WWW-Authenticate", "Basic realm=\"Couchbase Lite\"");
                 response.setStatus(401);
                 return;
@@ -175,7 +175,7 @@ public class LiteServlet extends HttpServlet {
                     }
                 }
             } else {
-                Log.w(Log.TAG_LISTENER, "authHeader is null");
+                Log.d(Log.TAG_LISTENER, "authHeader is null");
             }
         } catch (Exception e) {
             Log.e(Log.TAG_LISTENER, "Exception getting basic auth credentials", e);


### PR DESCRIPTION
I've been seeing many warning messages like this one:
```
11-09 18:43:21.329 12076-12899/com.joshblour.proximator.android W/Listener: authHeader is null
11-09 18:43:21.330 12076-12899/com.joshblour.proximator.android W/Listener: Unauthorized -- requestCredentials not given or do not match allowed credentials
```
These only appeared when replication iOS to Android so I opened an issue on the iOS library: https://github.com/couchbase/couchbase-lite-ios/issues/971

Apparently, 401 is a normal part of even a *valid* authentication process; an authorized user. Because of this, I've changed the log level for these messages to Debug instead of Warn. 