### PR TITLE
Fixed Java Core 1008 - External property on database change event

### DIFF
--- a/src/main/java/com/couchbase/lite/listener/LiteServlet.java
+++ b/src/main/java/com/couchbase/lite/listener/LiteServlet.java
@@ -190,15 +190,20 @@ public class LiteServlet extends HttpServlet {
         String addr = req.getRemoteAddr();
         Log.v(Log.TAG_LISTENER, "remoteURL() addr=" + addr);
         if (!"127.0.0.1".equals(addr) && !"::1".equals(addr)) {
+            // IPv6
             if (addr.indexOf(':') >= 0)
                 addr = String.format("[%s]", addr);
 
-            // Java URL can not set username
-            //String username = allowedCredentials != null ? allowedCredentials.getLogin() : null;
 
+            String username = allowedCredentials != null ? allowedCredentials.getLogin() : null;
             String protocol = req.isSecure() ? "https" : "http";
+            String spec = null;
+            if(username != null && username.length() > 0)
+                spec = String.format("%s://%s@%s/", protocol, username, addr);
+            else
+                spec = String.format("%s://%s/", protocol, addr);
             try {
-                return new URL(protocol, addr, "/");
+                return new URL(spec);
             } catch (MalformedURLException e) {
                 Log.w(Log.TAG_LISTENER, "failed to create remote URL", e);
                 return null;


### PR DESCRIPTION
Document insertion from Router set null for source property. In case REST API access is from remote (Router), needs to set remote URL. The source URL is set from Listener.