### PR TITLE
Fixed #1030 - Requests to Listener in pending state

### DIFF
--- a/src/main/java/com/couchbase/lite/listener/LiteServlet.java
+++ b/src/main/java/com/couchbase/lite/listener/LiteServlet.java
@@ -100,25 +100,23 @@ public class LiteServlet extends HttpServlet {
         final Router router = new Router(manager, conn);
 
         RouterCallbackBlock callbackBlock = new RouterCallbackBlock() {
-
             @Override
             public void onResponseReady() {
+                Log.v(Log.TAG_LISTENER, "RouterCallbackBlock.onResponseReady() START");
                 //set the response code
                 response.setStatus(conn.getResponseCode());
-
                 //add the resonse headers
                 Map<String, List<String>> headers = conn.getHeaderFields();
-                if(headers != null) {
+                if (headers != null) {
                     for (String headerName : headers.keySet()) {
                         for (String headerValue : headers.get(headerName)) {
                             response.addHeader(headerName, headerValue);
                         }
                     }
                 }
-
                 doneSignal.countDown();
+                Log.v(Log.TAG_LISTENER, "RouterCallbackBlock.onResponseReady() END");
             }
-
         };
 
         router.setCallbackBlock(callbackBlock);
@@ -126,12 +124,13 @@ public class LiteServlet extends HttpServlet {
         // set remote URL as source
         router.setSource(remoteURL(request));
 
-        synchronized (manager) {
-            router.start();
-        }
+        router.start();
 
         try {
+            Log.v(Log.TAG_LISTENER, "CountDownLatch.await() START");
             doneSignal.await();
+            Log.v(Log.TAG_LISTENER, "CountDownLatch.await() END");
+
             InputStream responseInputStream = conn.getResponseInputStream();
             final byte[] buffer = new byte[65536];
             int r;
@@ -144,11 +143,10 @@ public class LiteServlet extends HttpServlet {
         } catch (InterruptedException e) {
             Log.e(Log.TAG_LISTENER, "Interrupted waiting for result", e);
         } finally {
-            if(router != null) {
+            if (router != null) {
                 router.stop();
             }
         }
-
     }
 
     public Credentials credentialsWithBasicAuthentication(HttpServletRequest req) {
@@ -158,7 +156,7 @@ public class LiteServlet extends HttpServlet {
                 StringTokenizer st = new StringTokenizer(authHeader);
                 if (st.hasMoreTokens()) {
                     String basic = st.nextToken();
-                        if (basic.equalsIgnoreCase("Basic")) {
+                    if (basic.equalsIgnoreCase("Basic")) {
                         try {
                             String credentials = new String(Base64.decode(st.nextToken()), "UTF-8");
                             Log.v(Log.TAG_LISTENER, "Credentials: ", credentials);
@@ -182,7 +180,6 @@ public class LiteServlet extends HttpServlet {
         } catch (Exception e) {
             Log.e(Log.TAG_LISTENER, "Exception getting basic auth credentials", e);
         }
-
         return null;
     }
 
@@ -193,7 +190,6 @@ public class LiteServlet extends HttpServlet {
             // IPv6
             if (addr.indexOf(':') >= 0)
                 addr = String.format("[%s]", addr);
-
 
             String username = allowedCredentials != null ? allowedCredentials.getLogin() : null;
             String protocol = req.isSecure() ? "https" : "http";
@@ -211,5 +207,4 @@ public class LiteServlet extends HttpServlet {
         }
         return null;
     }
-
 }


### PR DESCRIPTION
- Remove synchronized(manager) block for router.start() that causes dead-lock.
- Add additional logging.