### PR TITLE
Fixed Java Core Issue 1592 - Find root cause of ConnectionError

### DIFF
--- a/vendor/tjws/src/java/Acme/Serve/Serve.java
+++ b/vendor/tjws/src/java/Acme/Serve/Serve.java
@@ -4140,6 +4140,16 @@ public class Serve implements ServletContext, Serializable {
 		        out.println(String.valueOf(contentLen));
 		    }
 		}
+
+			// In case keepalive=true and times of requested eqauls with max times connection use,
+			// set connection: close, and reset keepalive header value.
+			// Because some of client does not take care keep-alive max parameter.
+			// REF: https://github.com/couchbase/couchbase-lite-java-core/issues/1592
+			if (timesRequested == serve.getMaxTimesConnectionUse() - 1) {
+				setHeader(CONNECTION, "close");
+				setHeader(KEEPALIVE, null);
+			}
+
 		// process keep alive headers
 		Object o = resHeaderNames.get(CONNECTION);
 		if (o instanceof String) {


### PR DESCRIPTION
TJWS close connection every 100 requests processed in case keep-alive is true. 100 times response header has `connection: keep-alive` and ‘keep-alive: …, max=100’.
However, some client does not take care max parameter of keep-alive header value. And the client reuse the socket (connection) for 101 times request, it seems fails to send if TJWS takes time  to close the socket.
As solution, to set `connection: close` and remove `keep-alive` header value if times of requested equals with maximum times connection used.